### PR TITLE
Extract friendly_id support into an optional concern and improve

### DIFF
--- a/lib/super_resources.rb
+++ b/lib/super_resources.rb
@@ -13,6 +13,7 @@ module SuperResources
   autoload_under 'support' do
     autoload :Cancan
     autoload :Draper
+    autoload :FriendlyId
     autoload :HasScope
   end
 end

--- a/lib/super_resources/resources.rb
+++ b/lib/super_resources/resources.rb
@@ -67,7 +67,7 @@ module SuperResources
     end
 
     def resource_finding(scope)
-      requires_friendly_find?(scope) ? scope.friendly.find(params[:id]) : scope.send(finder_method, params[:id])
+      scope.send(finder_method, params[:id])
     end
 
     def finding_scope
@@ -76,10 +76,6 @@ module SuperResources
 
     def memoize_resource(&block)
       @_resource ||= block.call
-    end
-
-    def requires_friendly_find?(klass)
-      klass.respond_to?(:friendly_id_config) && !klass.friendly_id_config.uses?(:finders)
     end
 
     def resource?

--- a/lib/super_resources/support/friendly_id.rb
+++ b/lib/super_resources/support/friendly_id.rb
@@ -1,0 +1,29 @@
+module SuperResources
+  module FriendlyId
+    extend ActiveSupport::Concern
+
+    protected
+
+    def resource_finding(scope)
+      # NOTE: only a handful of finder methods are provided by friendly_id, so
+      #       provide some feedback if #finder_method would short-circuit
+      unless friendly_finders.include?(finder_method.to_sym)
+        raise NoMethodError.new("Unfriendly finder method `#{finder_method}'")
+      end
+
+      friendly?(scope) ? super : super(scope.friendly)
+    end
+
+    private
+
+    def friendly?(klass = resource_class)
+      klass.method(:find) \
+           .owner == ::FriendlyId::FinderMethods
+    end
+
+    def friendly_finders
+      @@friendly_finders ||=
+        ::FriendlyId::FinderMethods.public_instance_methods
+    end
+  end
+end


### PR DESCRIPTION
Because even if a model extends `FriendlyId`, and has finders configured, the `#find` method won't work unless the `#friendly` scope was the last scope called before the query is executed

This module will now need to be specifically included for any controllers that what to support friendly id/slugs 